### PR TITLE
feat: add batch deletion support to delete_note tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Batch deletion support in `delete_note` tool - can now delete multiple notes at once
+- `delete_note` tool now accepts either `noteId` (single) or `noteIds` (array for batch deletion)
+- Enhanced response format showing `deletedCount` and array of deleted `noteIds`
 - GitHub Actions workflow for automated npm publishing
 - GitHub Actions workflow for testing on pull requests
 - Release test workflow to ensure quality before publishing
@@ -18,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Robust version validation supporting multiple tag formats
 - npm package configuration
 - Installation instructions for npm package
+
+### Changed
+- `delete_note` tool description updated to "Delete one or multiple notes"
 
 ## [0.1.0] - 2025-03-20
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Model Context Protocol (MCP) server that enables LLMs to interact with Anki fl
 - `search_notes` - Search for notes using Anki query syntax
 - `get_note_info` - Get detailed information about a note
 - `update_note` - Update an existing note
-- `delete_note` - Delete a note
+- `delete_note` - Delete one or multiple notes
 - `list_note_types` - List all available note types
 - `create_note_type` - Create a new note type
 - `get_note_type_info` - Get detailed structure of a note type
@@ -127,6 +127,16 @@ Back: A closure is the combination of a function and the lexical environment wit
 ```
 Create a cloze card in the "Programming" deck with:
 Text: In JavaScript, {{c1::const}} declares a block-scoped variable that cannot be {{c2::reassigned}}.
+```
+
+4. Delete a single note:
+```
+Delete note ID 1234567890
+```
+
+5. Delete multiple notes at once:
+```
+Delete note IDs 1234567890, 9876543210, and 1122334455
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2372,9 +2372,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3486,9 +3486,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6697,10 +6697,11 @@
       }
     },
     "node_modules/sucrase/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -203,16 +203,24 @@ export class McpToolHandler {
 				},
 				{
 					name: "delete_note",
-					description: "Delete a note",
+					description: "Delete one or multiple notes",
 					inputSchema: {
 						type: "object",
 						properties: {
 							noteId: {
 								type: "number",
-								description: "Note ID to delete",
+								description: "Single note ID to delete",
+							},
+							noteIds: {
+								type: "array",
+								items: {
+									type: "number",
+								},
+								description: "Multiple note IDs to delete",
 							},
 						},
-						required: ["noteId"],
+						required: [],
+						additionalProperties: false,
 					},
 				},
 				{
@@ -905,19 +913,49 @@ export class McpToolHandler {
 	}
 
 	/**
-	 * Delete a note
+	 * Delete one or multiple notes
 	 */
-	private async deleteNote(args: { noteId: number }): Promise<{
+	private async deleteNote(args: {
+		noteId?: number;
+		noteIds?: number[];
+	}): Promise<{
 		content: {
 			type: string;
 			text: string;
 		}[];
 	}> {
-		if (!args.noteId) {
-			throw new McpError(ErrorCode.InvalidParams, "Note ID is required");
+		// Validation: exactly one parameter must be provided
+		const hasNoteId = args.noteId !== undefined;
+		const hasNoteIds = args.noteIds !== undefined && args.noteIds.length > 0;
+
+		if (!hasNoteId && !hasNoteIds) {
+			throw new McpError(
+				ErrorCode.InvalidParams,
+				"Either noteId or noteIds must be provided",
+			);
 		}
 
-		await this.ankiClient.deleteNotes([args.noteId]);
+		if (hasNoteId && hasNoteIds) {
+			throw new McpError(
+				ErrorCode.InvalidParams,
+				"Provide either noteId OR noteIds, not both",
+			);
+		}
+
+		// Determine which IDs to delete
+		const idsToDelete = hasNoteId
+			? [args.noteId as number]
+			: (args.noteIds as number[]);
+
+		// Validate all IDs are valid numbers
+		if (idsToDelete.some((id) => !Number.isInteger(id) || id <= 0)) {
+			throw new McpError(
+				ErrorCode.InvalidParams,
+				"All note IDs must be positive integers",
+			);
+		}
+
+		await this.ankiClient.deleteNotes(idsToDelete);
 
 		return {
 			content: [
@@ -926,7 +964,8 @@ export class McpToolHandler {
 					text: JSON.stringify(
 						{
 							success: true,
-							noteId: args.noteId,
+							deletedCount: idsToDelete.length,
+							noteIds: idsToDelete,
 						},
 						null,
 						2,


### PR DESCRIPTION
## Summary
Added batch deletion support to the `delete_note` tool to enable efficient removal of multiple notes at once.

## Motivation
 This feature enhances the user experience when managing large numbers of notes by:

  1. **Efficient Context Usage**: Batch operations significantly reduce the conversation context consumed, allowing users to use the same conversation on Claude Desktop longer.

  2. **Reduced API Usage**: Single tool call uses less compute than multiple tool call to delete single cards, so API rate limits can be stretched further.

Previously, I needed to delete dozens of unused vocabulary cards from a template deck, and being able to delete them all at once would have saved significant time and made the process much smoother.

## Changes
- Enhanced `delete_note` tool to accept either `noteId` (single) or `noteIds` (array)
- Added validation to ensure exactly one parameter is provided
- Maintained full backward compatibility - existing single deletions work unchanged
- Updated response format to include `deletedCount` and array of deleted `noteIds`
- Updated README.md with usage examples
- Updated CHANGELOG.md to document the feature

## Testing (tested locally with Claude Desktop)
  - ✅ Single deletion: `delete_note` with `noteId` works as before
  - ✅ Batch deletion: Successfully deleted multiple notes with `noteIds` array
  - ✅ Validation: Rejects calls with both parameters or neither parameter

## Breaking Changes
 None - the tool maintains full backward compatibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds batch deletion to `delete_note`, accepting `noteId` or `noteIds`, with validation and a response including `deletedCount` and `noteIds`, plus README/CHANGELOG updates.
> 
> - **Tools/Backend**:
>   - `delete_note`: support single or multiple deletions via `noteId` or `noteIds`.
>     - Input schema updated (optional `noteId` or `noteIds`, `additionalProperties: false`).
>     - Validation ensures exactly one parameter and positive integer IDs.
>     - Executes deletion for all IDs; response now includes `deletedCount` and `noteIds`.
> - **Docs**:
>   - README: updated tool description; added examples for single and batch deletion.
>   - CHANGELOG: noted batch deletion support and description change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c98c99f9459e9d7676a47ce06927a138dc465a05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->