### PR TITLE
fix: resolve MCP tool naming compliance and case sensitivity issues

### DIFF
--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -147,8 +147,21 @@ export class McpToolHandler {
 			if (!tool) {
 				const typeToolMatch = name.match(/^create_(.+)_note$/);
 				if (typeToolMatch) {
-					const modelName = typeToolMatch[1].replace(/_/g, " ");
-					tool = new CreateModelSpecificNoteTool(this.ankiClient, modelName);
+					// Get the lowercase version from the tool name
+					const lowercaseModelName = typeToolMatch[1].replace(/_/g, " ");
+
+					// Find the actual model name with correct casing
+					const modelNames = await this.ankiClient.getModelNames();
+					const actualModelName = modelNames.find(
+						(m) => m.toLowerCase() === lowercaseModelName,
+					);
+
+					if (actualModelName) {
+						tool = new CreateModelSpecificNoteTool(
+							this.ankiClient,
+							actualModelName,
+						);
+					}
 				}
 			}
 

--- a/src/tools/noteTools.ts
+++ b/src/tools/noteTools.ts
@@ -452,10 +452,14 @@ export class CreateModelSpecificNoteTool extends BaseTool implements IMcpTool {
 	name: string;
 	description: string;
 	inputSchema: Record<string, any>;
+	private originalModelName: string;
 
 	constructor(ankiClient: AnkiClient, modelName: string) {
 		super(ankiClient);
-		this.name = `create_${modelName.toLowerCase().replace(/ /g, "_")}_note`;
+		this.originalModelName = modelName;
+		this.name = `create_${modelName
+			.toLowerCase()
+			.replace(/[^a-zA-Z0-9_-]/g, "_")}_note`;
 		this.description = `Create a new note of type ${modelName}`;
 		this.inputSchema = {
 			type: "object",
@@ -475,10 +479,7 @@ export class CreateModelSpecificNoteTool extends BaseTool implements IMcpTool {
 		args: Record<string, any>,
 	): Promise<{ content: { type: string; text: string }[] }> {
 		try {
-			const modelName = this.name
-				.replace(/^create_/, "")
-				.replace(/_note$/, "")
-				.replace(/_/g, " ");
+			const modelName = this.originalModelName;
 
 			if (!args.deck) {
 				throw new McpError(ErrorCode.InvalidParams, "Deck name is required");


### PR DESCRIPTION
## Summary
This PR fixes critical bugs in v0.2.0 that prevent the MCP server from starting due to dynamic tool name generation issues. The fixes ensure MCP compliance and proper case handling for note type names.

## User Experience
When I tried to run the server from a local clone of `release-beta/0.2.0` branch, I got this error message in Claude Desktop.
<img width="1063" height="239" alt="Screenshot 2025-07-23 at 9 27 24 AM" src="https://github.com/user-attachments/assets/d967228c-0366-4d84-9739-33e07a67b7fe" />

## Diagnosis

The v0.2.0 release introduced dynamic tool generation that broke in two ways:

1. **MCP Naming Violation**: Tool names only replaced spaces but not other special characters, causing MCP validation failures:
   ```
   tools.23.FrontendRemoteMcpToolDefinition.name: String should match pattern '^[a-zA-Z0-9_\-]{1,64}'
   ```
   This prevented the server from starting when note types contained characters like parentheses, brackets, or other symbols.

2. **Case Sensitivity Bug**: Tool names were lowercased for MCP compliance, but the original case wasn't preserved for Anki API calls. This caused runtime failures when creating notes (e.g., "Japanese-75658" vs "japanese-75658").

## Solution
- **Regex Fix**: Updated sanitization from `.replace(/ /g, "_")` to `.replace(/[^a-zA-Z0-9_-]/g, "_")` to handle all non-MCP-compliant characters
- **Case Preservation**: Added `originalModelName` property to store the actual model name with correct casing
- **Dynamic Lookup**: Enhanced `executeTool` to find actual model names with correct casing during dynamic tool creation

## Changes
- `src/tools/noteTools.ts`: Added proper sanitization and case preservation in `CreateModelSpecificNoteTool`
- `src/mcpTools.ts`: Fixed dynamic tool creation to lookup correct model name casing

## Testing
- ✅ Server starts successfully with note types containing special characters
- ✅ Dynamic tools work with mixed-case note types (e.g., "Japanese-75658")
- ✅ MCP validation passes without errors
- ✅ Note creation succeeds with dynamically generated tools

## New Issues Identified
During testing, we discovered that some tools are returning "No result received from client-side tool execution" errors:
 - get_card_info
 - search_notes
 - get_note_info

I can't say for sure if it is an issue with the code or with my Claude Desktop app. Suggest to investigate this further.


## Impact
- Fixes critical startup failures in v0.2.0
- No breaking changes
- Maintains backward compatibility