### PR TITLE
Share configured Anki client and fix batch defaults

### DIFF
--- a/src/ankiMcpServer.ts
+++ b/src/ankiMcpServer.ts
@@ -51,8 +51,8 @@ export class AnkiMcpServer {
 		this.ankiClient = new AnkiClient({
 			ankiConnectUrl: `http://localhost:${port}`,
 		});
-		this.resourceHandler = new McpResourceHandler();
-		this.toolHandler = new McpToolHandler();
+		this.resourceHandler = new McpResourceHandler(this.ankiClient);
+		this.toolHandler = new McpToolHandler(this.ankiClient);
 
 		this.setupHandlers();
 

--- a/src/mcpResource.ts
+++ b/src/mcpResource.ts
@@ -14,8 +14,8 @@ export class McpResourceHandler {
 	private cacheExpiry: number;
 	private lastCacheUpdate: number;
 
-	constructor() {
-		this.ankiClient = new AnkiClient();
+	constructor(ankiClient?: AnkiClient) {
+		this.ankiClient = ankiClient ?? new AnkiClient();
 		this.modelSchemaCache = new Map();
 		this.allModelSchemasCache = null;
 		this.cacheExpiry = 5 * 60 * 1000; // 5 minutes

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -10,8 +10,8 @@ import { AnkiClient } from "./utils.js";
 export class McpToolHandler {
 	private ankiClient: AnkiClient;
 
-	constructor() {
-		this.ankiClient = new AnkiClient();
+	constructor(ankiClient?: AnkiClient) {
+		this.ankiClient = ankiClient ?? new AnkiClient();
 	}
 
 	/**
@@ -730,7 +730,7 @@ export class McpToolHandler {
 			index: number;
 		}[] = [];
 
-		const stopOnError = args.stopOnError !== false;
+		const stopOnError = args.stopOnError ?? false;
 
 		// Process each note
 		for (let i = 0; i < args.notes.length; i++) {


### PR DESCRIPTION
## Summary
- reuse a single configured AnkiClient across the server, resource handler, and tool handler
- default batch_create_notes stopOnError to false to align with the documented schema

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a2e40b60c8320b880f99c032217df)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Share a single configured AnkiClient across server/resource/tool handlers and default batch_create_notes stopOnError to false.
> 
> - **Core**:
>   - Share a single configured `AnkiClient` instance from `src/ankiMcpServer.ts` to `McpResourceHandler` and `McpToolHandler`.
>   - Update constructors in `src/mcpResource.ts` and `src/mcpTools.ts` to accept an optional `AnkiClient` (fallback to new instance).
> - **Tools**:
>   - In `batch_create_notes`, change `stopOnError` default to `false` via `args.stopOnError ?? false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f392a3d6a80e791545489facab06a0dd4f5379a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->