### PR TITLE
feat: add --host flag for remote AnkiConnect connections

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,8 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["**/*.test.ts", "**/*.spec.ts"]
+		"includes": ["**", "!**/*.test.ts", "!**/*.spec.ts"]
 	},
 	"formatter": {
 		"enabled": true,
@@ -12,9 +12,7 @@
 		"lineEnding": "lf",
 		"lineWidth": 100
 	},
-	"organizeImports": {
-		"enabled": true
-	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {
@@ -25,7 +23,7 @@
 		"formatter": {
 			"jsxQuoteStyle": "double",
 			"quoteProperties": "asNeeded",
-			"trailingComma": "es5",
+			"trailingCommas": "es5",
 			"semicolons": "always",
 			"arrowParentheses": "always",
 			"bracketSpacing": true,

--- a/src/ankiMcpServer.ts
+++ b/src/ankiMcpServer.ts
@@ -29,7 +29,7 @@ export class AnkiMcpServer {
 	/**
 	 * Constructor
 	 */
-	constructor(port = 8765) {
+	constructor(port = 8765, host = "localhost") {
 		this.server = new Server(
 			{
 				name: "anki-connect-server",
@@ -49,7 +49,7 @@ export class AnkiMcpServer {
 		);
 
 		this.ankiClient = new AnkiClient({
-			ankiConnectUrl: `http://localhost:${port}`,
+			ankiConnectUrl: `http://${host}:${port}`,
 		});
 		this.resourceHandler = new McpResourceHandler();
 		this.toolHandler = new McpToolHandler();

--- a/src/ankiMcpServer.ts
+++ b/src/ankiMcpServer.ts
@@ -51,8 +51,8 @@ export class AnkiMcpServer {
 		this.ankiClient = new AnkiClient({
 			ankiConnectUrl: `http://${host}:${port}`,
 		});
-		this.resourceHandler = new McpResourceHandler();
-		this.toolHandler = new McpToolHandler();
+		this.resourceHandler = new McpResourceHandler(this.ankiClient);
+		this.toolHandler = new McpToolHandler(this.ankiClient);
 
 		this.setupHandlers();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,10 @@ function parseArgs() {
 		process.exit(1);
 	}
 
-	return { port };
+	const hostIndex = args.indexOf("--host");
+	const host = hostIndex !== -1 && args[hostIndex + 1] ? args[hostIndex + 1] : "localhost";
+
+	return { port, host };
 }
 
 /**
@@ -25,8 +28,8 @@ function parseArgs() {
  */
 async function main() {
 	try {
-		const { port } = parseArgs();
-		const server = new AnkiMcpServer(port);
+		const { port, host } = parseArgs();
+		const server = new AnkiMcpServer(port, host);
 		await server.run();
 	} catch (error) {
 		console.error("Failed to start Anki MCP Server:", error);

--- a/src/mcpResource.ts
+++ b/src/mcpResource.ts
@@ -14,8 +14,8 @@ export class McpResourceHandler {
 	private cacheExpiry: number;
 	private lastCacheUpdate: number;
 
-	constructor() {
-		this.ankiClient = new AnkiClient();
+	constructor(ankiClient?: AnkiClient) {
+		this.ankiClient = ankiClient ?? new AnkiClient();
 		this.modelSchemaCache = new Map();
 		this.allModelSchemasCache = null;
 		this.cacheExpiry = 5 * 60 * 1000; // 5 minutes

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -10,8 +10,8 @@ import { AnkiClient } from "./utils.js";
 export class McpToolHandler {
 	private ankiClient: AnkiClient;
 
-	constructor() {
-		this.ankiClient = new AnkiClient();
+	constructor(ankiClient?: AnkiClient) {
+		this.ankiClient = ankiClient ?? new AnkiClient();
 	}
 
 	/**
@@ -511,10 +511,7 @@ export class McpToolHandler {
 	/**
 	 * Get note type info
 	 */
-	private async getNoteTypeInfo(args: {
-		modelName: string;
-		includeCss?: boolean;
-	}): Promise<{
+	private async getNoteTypeInfo(args: { modelName: string; includeCss?: boolean }): Promise<{
 		content: {
 			type: string;
 			text: string;


### PR DESCRIPTION
## Summary
- Add `--host <address>` CLI flag to specify the AnkiConnect host (defaults to `localhost`)
- Enables connecting to AnkiConnect running on a remote machine (e.g. via Tailscale or LAN)
- Also migrates `biome.json` to v2 schema to fix pre-commit hook compatibility

## Motivation
When running the MCP server on a headless machine (e.g. Raspberry Pi) while Anki runs on a desktop PC, `localhost` doesn't work. The `--host` flag allows specifying the remote address directly.

## Usage
```json
{
  "mcpServers": {
    "anki": {
      "command": "npx",
      "args": ["-y", "anki-mcp-server", "--host", "192.168.1.100"]
    }
  }
}
```

## Test plan
- [x] Verified `--host 100.x.x.x` connects to remote AnkiConnect via Tailscale
- [x] Verified default behavior (`localhost`) is unchanged when `--host` is omitted
- [x] Pre-commit hooks pass after biome migration