### PR TITLE
feat: add sync tool to trigger AnkiWeb sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A Model Context Protocol (MCP) server that enables LLMs to interact with Anki fl
 - `list_note_types` - List all available note types
 - `create_note_type` - Create a new note type
 - `get_note_type_info` - Get detailed structure of a note type
+- `sync` - Trigger AnkiWeb sync (fire-and-forget; success means Anki accepted the request, not that AnkiWeb received the data — a blocking dialog in Anki can silently keep the sync queued)
 
 ### Resources
 

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -36,6 +36,16 @@ export class McpToolHandler {
 					},
 				},
 				{
+					name: "sync",
+					description:
+						"Sync the local Anki collection with AnkiWeb (push local changes, pull remote ones). Requires the user to be signed into AnkiWeb via the Anki GUI.",
+					inputSchema: {
+						type: "object",
+						properties: {},
+						required: [],
+					},
+				},
+				{
 					name: "create_deck",
 					description: "Create a new Anki deck",
 					inputSchema: {
@@ -332,6 +342,10 @@ export class McpToolHandler {
 				case "create_deck":
 					return this.createDeck(a);
 
+				// Sync
+				case "sync":
+					return this.sync();
+
 				// Note type tools
 				case "list_note_types":
 					return this.listNoteTypes();
@@ -380,6 +394,26 @@ export class McpToolHandler {
 				isError: true,
 			};
 		}
+	}
+
+	/**
+	 * Trigger an AnkiWeb sync
+	 */
+	private async sync(): Promise<{
+		content: {
+			type: string;
+			text: string;
+		}[];
+	}> {
+		await this.ankiClient.sync();
+		return {
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({ success: true, message: "Sync triggered" }, null, 2),
+				},
+			],
+		};
 	}
 
 	/**

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -38,7 +38,7 @@ export class McpToolHandler {
 				{
 					name: "sync",
 					description:
-						"Sync the local Anki collection with AnkiWeb (push local changes, pull remote ones). Requires the user to be signed into AnkiWeb via the Anki GUI.",
+						"Trigger a sync between the local Anki collection and AnkiWeb. Fire-and-forget: success means Anki accepted the request, not that AnkiWeb received the data. If a blocking dialog is open in Anki (sync conflict, full-sync prompt, re-auth), the sync stays queued until a human dismisses it. Requires the user to be signed into AnkiWeb via the Anki GUI.",
 					inputSchema: {
 						type: "object",
 						properties: {},
@@ -397,7 +397,7 @@ export class McpToolHandler {
 	}
 
 	/**
-	 * Trigger an AnkiWeb sync
+	 * Trigger an AnkiWeb sync. Fire-and-forget — see AnkiClient.sync().
 	 */
 	private async sync(): Promise<{
 		content: {
@@ -410,7 +410,15 @@ export class McpToolHandler {
 			content: [
 				{
 					type: "text",
-					text: JSON.stringify({ success: true, message: "Sync triggered" }, null, 2),
+					text: JSON.stringify(
+						{
+							success: true,
+							message:
+								"Sync requested. AnkiConnect does not confirm completion; if changes don't appear on AnkiWeb, check Anki for a pending dialog.",
+						},
+						null,
+						2
+					),
 				},
 			],
 		};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -171,10 +171,10 @@ export class AnkiClient {
 	}
 
 	/**
-	 * Trigger a sync with AnkiWeb. Pushes local changes and pulls remote ones.
-	 * The user must already be signed in via the Anki GUI (credentials live in prefs21.db).
-	 * Returns when the sync completes server-side; the underlying AnkiConnect action
-	 * is fire-and-resolve, so a successful response means Anki accepted the request.
+	 * Trigger a sync between the local collection and AnkiWeb. Fire-and-forget:
+	 * AnkiConnect acknowledges the request but does not confirm completion.
+	 * If a blocking dialog is open in Anki, the sync stays queued until it's
+	 * dismissed.
 	 */
 	async sync(): Promise<void> {
 		try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -171,6 +171,20 @@ export class AnkiClient {
 	}
 
 	/**
+	 * Trigger a sync with AnkiWeb. Pushes local changes and pulls remote ones.
+	 * The user must already be signed in via the Anki GUI (credentials live in prefs21.db).
+	 * Returns when the sync completes server-side; the underlying AnkiConnect action
+	 * is fire-and-resolve, so a successful response means Anki accepted the request.
+	 */
+	async sync(): Promise<void> {
+		try {
+			await this.executeWithRetry(() => this.client.invoke("sync"));
+		} catch (error) {
+			throw this.wrapError(error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+
+	/**
 	 * Get all deck names
 	 */
 	async getDeckNames(): Promise<string[]> {


### PR DESCRIPTION
## Summary
Adds a new MCP tool, `sync`, that triggers AnkiConnect's `sync` action so an LLM client can push local changes and pull remote ones from AnkiWeb without the user leaving the conversation.

## Motivation
A common workflow is: ask the LLM to add a batch of cards, then sync them to AnkiWeb so they're available on mobile. Today that second step requires the user to switch focus to Anki and click Sync. Exposing it as a tool closes the loop.

## Implementation
- `AnkiClient.sync()` in `src/utils.ts` — thin wrapper around `client.invoke("sync")`, matching the style of `checkConnection()`.
- New tool schema entry + dispatch case + private handler in `src/mcpTools.ts`. The tool takes no arguments.

## Limitation: fire-and-forget

I explored returning a richer signal — verifying that AnkiWeb actually received the data, and surfacing a useful error when a blocking GUI dialog (full-sync prompt, sync-conflict prompt, re-auth prompt) keeps the sync queued — but every approach has a sharp edge, so this PR ships the simple fire-and-forget version. The tool description and success message now make that explicit.

What I tried, and why I dropped each:

1. **`col.ls` polling.** Open `collection.anki2` read-only (Anki uses WAL, so this is safe alongside Anki's writer), snapshot `col.ls` before firing sync, poll for it to advance, time out otherwise. Worked in the happy path, but: `col.ls` only advances when there's *something to push or pull*. A no-op sync (already in sync) leaves it untouched, so the poll falsely times out and reports the sync as stalled. Also adds a native dependency (`better-sqlite3`) which feels heavy for one feature.
2. **AnkiConnect-side completion endpoint.** Doesn't exist. `apiReflect` confirmed there's no action that returns `col.ls`, sync status, or any value that flips on completion. Closest are `version` and `cardsModTime`, neither of which moves with sync.
3. **Behavioral / heartbeat signals.** Anything we could ask AnkiConnect for (version, getProfiles, etc.) responds independently of sync state — sync runs on Anki's main thread but the HTTP server runs on its own, so a stalled sync doesn't make AnkiConnect unresponsive.
4. **GUI-side modal detection (xdotool / window enumeration).** Catches the actual failure mode reliably, but it's Linux/X11-only — not portable enough for upstream. Worth keeping as an optional layer in headless deployments, not in this package.

The remaining honest behavior: trigger the sync, return success when Anki accepts the request, and document clearly that "success" does not mean "AnkiWeb has the data". When a blocking dialog is in play, the user is the only one who can resolve it — surfacing that in the description gives the LLM enough context to tell them so.

## Test plan
- [x] `npm run build` succeeds.
- [x] Stdio smoke test: server returns `sync` in `tools/list`.
- [x] `tools/call` with `name=sync` against a running, signed-in Anki returns success and triggers a real AnkiWeb sync (verified end-to-end by deck/note changes propagating to the AnkiWeb web UI and a mobile client).
- [ ] (Reviewer note) No unit tests added since the repo currently has no test files for the existing tools — happy to add a mocked test if you'd like, just point me at the pattern you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
