### PR TITLE
feat: add batch note deletion support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Batch deletion support in `delete_note` tool
+- `delete_note` tool now accepts either `noteId` for one note or `noteIds` for multiple notes
+- Enhanced `delete_note` response format with `deletedCount` and deleted `noteIds`
 - GitHub Actions workflow for automated npm publishing
 - GitHub Actions workflow for testing on pull requests
 - Release test workflow to ensure quality before publishing
@@ -18,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Robust version validation supporting multiple tag formats
 - npm package configuration
 - Installation instructions for npm package
+
+### Changed
+- `delete_note` tool description now reflects single-note and batch deletion support
 
 ## [0.1.0] - 2025-03-20
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) server that enables LLMs to interact with Anki fl
 - `search_notes` - Search for notes using Anki query syntax
 - `get_note_info` - Get detailed information about a note
 - `update_note` - Update an existing note
-- `delete_note` - Delete a note
+- `delete_note` - Delete one or multiple notes
 - `list_note_types` - List all available note types
 - `create_note_type` - Create a new note type
 - `get_note_type_info` - Get detailed structure of a note type
@@ -241,6 +241,18 @@ Back: A closure is the combination of a function and the lexical environment wit
 ```
 Create a cloze card in the "Programming" deck with:
 Text: In JavaScript, {{c1::const}} declares a block-scoped variable that cannot be {{c2::reassigned}}.
+```
+
+4. Delete a single note:
+
+```
+Delete note ID 1234567890
+```
+
+5. Delete multiple notes at once:
+
+```
+Delete note IDs 1234567890, 9876543210, and 1122334455
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -21,19 +21,14 @@
         "lint": "biome lint src/",
         "check": "biome check --apply .",
         "inspector": "npx @modelcontextprotocol/inspector dist/index.js",
-        "test": "jest --runInBand --detectOpenHandles",
+        "test": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand --detectOpenHandles",
         "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
         "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
         "test:language": "node test-language.js"
     },
     "lint-staged": {
-        "src/**/*.{js,jsx,ts,tsx}": [
-            "biome format --write",
-            "git add"
-        ],
-        "src/**/*.test.ts": [
-            "biome format --write",
-            "git add"
+        "src/**/!(*.test|*.spec).{js,jsx,ts,tsx}": [
+            "biome format --write"
         ]
     },
     "dependencies": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,33 @@
-import { describe, it, expect } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { McpToolHandler } from "./mcpTools.js";
+import type { AnkiClient } from "./utils.js";
+
+type ToolResponse = {
+	content: {
+		type: string;
+		text: string;
+	}[];
+};
+
+type DeleteNoteArgs = {
+	noteId?: number;
+	noteIds?: number[];
+};
+
+type DeleteNoteHandler = {
+	deleteNote(args: DeleteNoteArgs): Promise<ToolResponse>;
+};
+
+const createDeleteNoteHarness = () => {
+	const deleteNotes = jest.fn<(ids: number[]) => Promise<void>>().mockResolvedValue();
+	const handler = new McpToolHandler({ deleteNotes } as unknown as AnkiClient);
+
+	return {
+		deleteNotes,
+		deleteNote: (handler as unknown as DeleteNoteHandler).deleteNote.bind(handler),
+	};
+};
 
 // Simple tests that don't require external dependencies
 describe("Anki MCP Server - Basic Tests", () => {
@@ -24,5 +53,51 @@ describe("Anki MCP Server - Basic Tests", () => {
 		expect(testObject).toHaveProperty("name");
 		expect(testObject.name).toBe("test");
 		expect(testObject.value).toBe(42);
+	});
+});
+
+describe("delete_note tool", () => {
+	it("should delete a single note by noteId", async () => {
+		const { deleteNote, deleteNotes } = createDeleteNoteHarness();
+
+		const result = await deleteNote({ noteId: 1234567890 });
+
+		expect(deleteNotes).toHaveBeenCalledWith([1234567890]);
+		expect(JSON.parse(result.content[0].text)).toEqual({
+			success: true,
+			deletedCount: 1,
+			noteIds: [1234567890],
+		});
+	});
+
+	it("should delete multiple notes by noteIds", async () => {
+		const { deleteNote, deleteNotes } = createDeleteNoteHarness();
+
+		const result = await deleteNote({ noteIds: [1234567890, 9876543210] });
+
+		expect(deleteNotes).toHaveBeenCalledWith([1234567890, 9876543210]);
+		expect(JSON.parse(result.content[0].text)).toEqual({
+			success: true,
+			deletedCount: 2,
+			noteIds: [1234567890, 9876543210],
+		});
+	});
+
+	it("should reject missing, duplicate, empty, or invalid note IDs", async () => {
+		const { deleteNote, deleteNotes } = createDeleteNoteHarness();
+
+		await expect(deleteNote({})).rejects.toMatchObject({
+			code: ErrorCode.InvalidParams,
+		} satisfies Partial<McpError>);
+		await expect(deleteNote({ noteId: 1, noteIds: [2] })).rejects.toMatchObject({
+			code: ErrorCode.InvalidParams,
+		} satisfies Partial<McpError>);
+		await expect(deleteNote({ noteIds: [] })).rejects.toMatchObject({
+			code: ErrorCode.InvalidParams,
+		} satisfies Partial<McpError>);
+		await expect(deleteNote({ noteIds: [1, 0] })).rejects.toMatchObject({
+			code: ErrorCode.InvalidParams,
+		} satisfies Partial<McpError>);
+		expect(deleteNotes).not.toHaveBeenCalled();
 	});
 });

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -250,16 +250,24 @@ export class McpToolHandler {
 				},
 				{
 					name: "delete_note",
-					description: "Delete a note",
+					description: "Delete one or multiple notes",
 					inputSchema: {
 						type: "object",
 						properties: {
 							noteId: {
 								type: "number",
-								description: "Note ID to delete",
+								description: "Single note ID to delete",
+							},
+							noteIds: {
+								type: "array",
+								items: {
+									type: "number",
+								},
+								description: "Multiple note IDs to delete",
 							},
 						},
-						required: ["noteId"],
+						required: [],
+						additionalProperties: false,
 					},
 				},
 				{
@@ -972,19 +980,32 @@ export class McpToolHandler {
 	}
 
 	/**
-	 * Delete a note
+	 * Delete one or multiple notes
 	 */
-	private async deleteNote(args: { noteId: number }): Promise<{
+	private async deleteNote(args: { noteId?: number; noteIds?: number[] }): Promise<{
 		content: {
 			type: string;
 			text: string;
 		}[];
 	}> {
-		if (!args.noteId) {
-			throw new McpError(ErrorCode.InvalidParams, "Note ID is required");
+		const hasNoteId = args.noteId !== undefined;
+		const hasNoteIds = args.noteIds !== undefined;
+
+		if (hasNoteId === hasNoteIds) {
+			throw new McpError(ErrorCode.InvalidParams, "Provide exactly one of noteId or noteIds");
 		}
 
-		await this.ankiClient.deleteNotes([args.noteId]);
+		const noteIds: number[] = hasNoteId ? [args.noteId as number] : (args.noteIds ?? []);
+
+		if (noteIds.length === 0) {
+			throw new McpError(ErrorCode.InvalidParams, "At least one note ID is required");
+		}
+
+		if (noteIds.some((id) => !Number.isInteger(id) || id <= 0)) {
+			throw new McpError(ErrorCode.InvalidParams, "All note IDs must be positive integers");
+		}
+
+		await this.ankiClient.deleteNotes(noteIds);
 
 		return {
 			content: [
@@ -993,7 +1014,8 @@ export class McpToolHandler {
 					text: JSON.stringify(
 						{
 							success: true,
-							noteId: args.noteId,
+							deletedCount: noteIds.length,
+							noteIds,
 						},
 						null,
 						2


### PR DESCRIPTION
## Summary
- Reimplements batch deletion support for the `delete_note` tool from #16.
- Allows either `noteId` for a single note or `noteIds` for multiple notes.
- Adds validation, response metadata (`deletedCount`, `noteIds`), docs, and tests.

## Context
References #16. Since that PR has been open for a long time, this is a fresh implementation of the same feature so it can move forward cleanly. Many thanks to @isaaclxy for the original contribution and clear motivation.

## Testing
- `npx tsc --noEmit`
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`
