### PR TITLE
[codex] Enforce Anki request timeouts

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import type { YankiFetchAdapter } from "yanki-connect";
+import { AnkiClient } from "./utils.js";
+
+const createJsonResponse = (result: unknown) => ({
+	headers: {},
+	json: async () => ({ error: null, result }),
+	status: 200,
+});
+
+describe("AnkiClient request timeouts", () => {
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it("passes an abort signal to the configured fetch adapter", async () => {
+		const fetchAdapter = jest
+			.fn<YankiFetchAdapter>()
+			.mockResolvedValue(createJsonResponse(6));
+		const client = new AnkiClient({ fetchAdapter, timeout: 100 });
+
+		await expect(client.getVersion()).resolves.toBe(6);
+
+		const [_input, init] = fetchAdapter.mock.calls[0];
+		expect(init).toMatchObject({
+			method: "POST",
+			mode: "cors",
+		});
+		expect((init as typeof init & { signal?: AbortSignal }).signal).toBeInstanceOf(
+			AbortSignal
+		);
+	});
+
+	it("converts adapter aborts into actionable MCP timeout errors", async () => {
+		jest.useFakeTimers();
+
+		const abortError = new Error("The operation was aborted");
+		abortError.name = "AbortError";
+		const fetchAdapter = jest.fn<YankiFetchAdapter>((_input, init) => {
+			const signal = (init as typeof init & { signal?: AbortSignal }).signal;
+
+			return new Promise((_resolve, reject) => {
+				signal?.addEventListener("abort", () => reject(abortError), { once: true });
+			});
+		});
+		const client = new AnkiClient({ fetchAdapter, retryTimeout: 1, timeout: 5 });
+
+		const result = client.getVersion();
+		const expectation = expect(result).rejects.toThrow(
+			"Connection to Anki timed out. Please check if Anki is responsive."
+		);
+
+		await jest.advanceTimersByTimeAsync(5);
+		await jest.advanceTimersByTimeAsync(1);
+		await jest.advanceTimersByTimeAsync(5);
+
+		await expectation;
+		expect(fetchAdapter).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Utility functions and anti-corruption layer for yanki-connect
  */
-import { YankiConnect } from "yanki-connect";
+import { YankiConnect, type YankiFetchAdapter } from "yanki-connect";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 
 /**
@@ -40,6 +40,7 @@ export interface AnkiConfig {
 	timeout: number;
 	retryTimeout: number;
 	defaultDeck: string;
+	fetchAdapter?: YankiFetchAdapter;
 }
 
 /**
@@ -74,7 +75,38 @@ export class AnkiClient {
 		this.client = new YankiConnect({
 			host: `${url.protocol}//${url.hostname}`,
 			port: parseInt(url.port, 10),
+			fetchAdapter: this.createTimeoutFetchAdapter(),
 		});
+	}
+
+	private createTimeoutFetchAdapter(): YankiFetchAdapter {
+		const fetchAdapter = this.config.fetchAdapter ?? (fetch.bind(globalThis) as YankiFetchAdapter);
+
+		return async (input, init) => {
+			if (this.config.timeout <= 0) {
+				return fetchAdapter(input, init);
+			}
+
+			const controller = new AbortController();
+			const timeout = setTimeout(() => controller.abort(), this.config.timeout);
+
+			try {
+				return await fetchAdapter(input, {
+					...init,
+					signal: controller.signal,
+				} as Parameters<YankiFetchAdapter>[1] & { signal: AbortSignal });
+			} catch (error) {
+				if (error instanceof Error && error.name === "AbortError") {
+					throw new AnkiTimeoutError(
+						"Connection to Anki timed out. Please check if Anki is responsive."
+					);
+				}
+
+				throw error;
+			} finally {
+				clearTimeout(timeout);
+			}
+		};
 	}
 
 	/**
@@ -115,6 +147,10 @@ export class AnkiClient {
 	 */
 	private normalizeError(error: unknown): Error {
 		if (error instanceof Error) {
+			if (error instanceof AnkiTimeoutError) {
+				return error;
+			}
+
 			// Connection errors
 			if (error.message.includes("ECONNREFUSED")) {
 				return new AnkiConnectionError(
@@ -123,7 +159,11 @@ export class AnkiClient {
 			}
 
 			// Timeout errors
-			if (error.message.includes("timeout") || error.message.includes("ETIMEDOUT")) {
+			if (
+				error.name === "AbortError" ||
+				error.message.includes("timeout") ||
+				error.message.includes("ETIMEDOUT")
+			) {
 				return new AnkiTimeoutError(
 					"Connection to Anki timed out. Please check if Anki is responsive."
 				);


### PR DESCRIPTION
## Summary
- Wrap yanki-connect fetch calls with an AbortController using the configured timeout.
- Preserve timeout errors through AnkiClient normalization so agents receive actionable MCP errors.
- Add low-level AnkiClient tests for AbortSignal injection and timeout conversion.

## Validation
- `npx tsc --noEmit`
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`
- `git diff --check`
- `pnpm lint && pnpm build && pnpm test`