### PR TITLE
[codex] Add Anki tag management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ A Model Context Protocol (MCP) server that enables LLMs to interact with Anki fl
 ### Tools
 
 - `anki_check_connection` - Check whether AnkiConnect is reachable
-- `anki_list_decks` - List all available Anki decks
+- `anki_list_decks` - List all available Anki decks, optionally with deck IDs
 - `anki_create_deck` - Create a new Anki deck
+- `anki_list_tags` - List all tags currently used in the collection
+- `anki_add_note_tags` - Add tags to one or more notes
+- `anki_remove_note_tags` - Remove tags from one or more notes
 - `anki_create_note` - Create a new note
 - `anki_batch_create_notes` - Create multiple notes at once
 - `anki_search_notes` - Search for notes using Anki query syntax
@@ -26,7 +29,8 @@ Legacy unprefixed tool names such as `create_note` and `list_decks` remain calla
 
 ### Resources
 
-- `anki://decks/all` - Complete list of available decks
+- `anki://decks/all` - Complete list of available decks with deck IDs
+- `anki://tags/all` - Complete list of tags
 - `anki://note-types/all` - List of all available note types
 - `anki://note-types/all-with-schemas` - Detailed structure information for all note types
 - `anki://note-types/{modelName}` - Detailed structure information for a specific note type
@@ -251,6 +255,12 @@ Delete note ID 1234567890
 
 ```
 Delete note IDs 1234567890, 9876543210, and 1122334455
+```
+
+6. Add tags to notes:
+
+```
+Add tags "review" and "mcp" to note IDs 1234567890 and 9876543210
 ```
 
 ## Contributing

--- a/manifest.json
+++ b/manifest.json
@@ -18,47 +18,67 @@
 	},
 	"tools": [
 		{
-			"name": "list_decks",
+			"name": "anki_check_connection",
+			"description": "Check whether AnkiConnect is reachable"
+		},
+		{
+			"name": "anki_list_decks",
 			"description": "List all available Anki decks"
 		},
 		{
-			"name": "create_deck",
+			"name": "anki_sync",
+			"description": "Request AnkiWeb sync"
+		},
+		{
+			"name": "anki_create_deck",
 			"description": "Create a new Anki deck"
 		},
 		{
-			"name": "create_note",
-			"description": "Create a new note (Basic or Cloze)"
+			"name": "anki_list_tags",
+			"description": "List all tags currently used in Anki"
 		},
 		{
-			"name": "batch_create_notes",
+			"name": "anki_add_note_tags",
+			"description": "Add tags to one or more notes"
+		},
+		{
+			"name": "anki_remove_note_tags",
+			"description": "Remove tags from one or more notes"
+		},
+		{
+			"name": "anki_create_note",
+			"description": "Create a new note"
+		},
+		{
+			"name": "anki_batch_create_notes",
 			"description": "Create multiple notes at once"
 		},
 		{
-			"name": "search_notes",
+			"name": "anki_search_notes",
 			"description": "Search for notes using Anki query syntax"
 		},
 		{
-			"name": "get_note_info",
+			"name": "anki_get_note_info",
 			"description": "Get detailed information about a note"
 		},
 		{
-			"name": "update_note",
-			"description": "Update an existing note"
+			"name": "anki_update_note",
+			"description": "Update an existing note's fields and/or tags"
 		},
 		{
-			"name": "delete_note",
-			"description": "Delete a note"
+			"name": "anki_delete_note",
+			"description": "Delete one or multiple notes"
 		},
 		{
-			"name": "list_note_types",
+			"name": "anki_list_note_types",
 			"description": "List all available note types"
 		},
 		{
-			"name": "create_note_type",
+			"name": "anki_create_note_type",
 			"description": "Create a new note type"
 		},
 		{
-			"name": "get_note_type_info",
+			"name": "anki_get_note_type_info",
 			"description": "Get detailed structure of a note type"
 		}
 	],

--- a/skills/anki/SKILL.md
+++ b/skills/anki/SKILL.md
@@ -36,6 +36,9 @@ Create and manage Anki flashcards through the `anki-mcp-server` MCP integration.
 | Check connection | `anki_check_connection` | — |
 | List all decks | `anki_list_decks` | — |
 | Create deck | `anki_create_deck` | `name` |
+| List all tags | `anki_list_tags` | — |
+| Add note tags | `anki_add_note_tags` | `noteId` or `noteIds`, `tags` |
+| Remove note tags | `anki_remove_note_tags` | `noteId` or `noteIds`, `tags` |
 | Create one note | `anki_create_note` | `type`, `deck`, `fields` |
 | Batch create notes | `anki_batch_create_notes` | `notes[]` (10–20 per batch) |
 | Search notes | `anki_search_notes` | `query` (Anki syntax), `limit`, `offset` |
@@ -104,6 +107,10 @@ is:new                   # Unseen cards
 note:Basic               # Cards using Basic note type
 "exact phrase"           # Exact text match
 ```
+
+### Tags
+
+Use `anki_list_tags` to inspect existing tags. For metadata-only changes, prefer `anki_add_note_tags` and `anki_remove_note_tags`; use `anki_update_note` only when replacing the full tag list.
 
 ## Deck Naming
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,7 +28,11 @@ const createMockClient = (overrides: Partial<Record<keyof AnkiClient, unknown>> 
 		sync: jest.fn<() => Promise<void>>().mockResolvedValue(),
 		checkConnection: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
 		getDeckNames: jest.fn<() => Promise<string[]>>().mockResolvedValue(["Default"]),
+		getDeckNamesAndIds: jest
+			.fn<() => Promise<Record<string, number>>>()
+			.mockResolvedValue({ Default: 1 }),
 		createDeck: jest.fn<(name: string) => Promise<number>>().mockResolvedValue(42),
+		getTags: jest.fn<() => Promise<string[]>>().mockResolvedValue(["programming"]),
 		getModelNames: jest.fn<() => Promise<string[]>>().mockResolvedValue(["Basic", "Cloze"]),
 		getModelFieldNames: jest
 			.fn<(modelName: string) => Promise<string[]>>()
@@ -50,6 +54,8 @@ const createMockClient = (overrides: Partial<Record<keyof AnkiClient, unknown>> 
 		notesInfo: jest.fn<AnkiClient["notesInfo"]>().mockResolvedValue([sampleNote]),
 		updateNoteFields: jest.fn<AnkiClient["updateNoteFields"]>().mockResolvedValue(),
 		updateNoteTags: jest.fn<AnkiClient["updateNoteTags"]>().mockResolvedValue(),
+		addTags: jest.fn<AnkiClient["addTags"]>().mockResolvedValue(),
+		removeTags: jest.fn<AnkiClient["removeTags"]>().mockResolvedValue(),
 		deleteNotes: jest.fn<(ids: number[]) => Promise<void>>().mockResolvedValue(),
 		...overrides,
 	}) as unknown as AnkiClient;
@@ -63,6 +69,7 @@ describe("McpToolHandler schema", () => {
 		expect(names).toContain("anki_create_note");
 		expect(names).toContain("anki_batch_create_notes");
 		expect(names).toContain("anki_check_connection");
+		expect(names).toContain("anki_list_tags");
 		expect(names).not.toContain("create_note");
 
 		const createNote = schema.tools.find((tool) => tool.name === "anki_create_note");
@@ -79,6 +86,16 @@ describe("McpToolHandler schema", () => {
 			additionalProperties: false,
 		});
 		expect(listDecks?.annotations).toMatchObject({ readOnlyHint: true });
+
+		const addTags = schema.tools.find((tool) => tool.name === "anki_add_note_tags");
+		expect(addTags?.inputSchema).toMatchObject({
+			oneOf: [{ required: ["noteId"] }, { required: ["noteIds"] }],
+		});
+		expect(addTags?.annotations).toMatchObject({
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+		});
 	});
 
 	it("keeps legacy tool names callable without advertising them", async () => {
@@ -106,6 +123,18 @@ describe("McpToolHandler schema", () => {
 		expect(result.content[0]).toMatchObject({
 			type: "text",
 			text: "Error: Anki is off",
+		});
+	});
+
+	it("lists decks with optional ID metadata", async () => {
+		const handler = new McpToolHandler(createMockClient());
+
+		const result = await handler.executeTool("anki_list_decks", { includeIds: true });
+
+		expect(result.structuredContent).toEqual({
+			decks: ["Default"],
+			deckIds: { Default: 1 },
+			count: 1,
 		});
 	});
 
@@ -284,6 +313,63 @@ describe("McpToolHandler maintenance workflows", () => {
 			noteId: 1234567890,
 			updatedFields: true,
 			updatedTags: true,
+		});
+	});
+
+	it("lists and mutates tags for notes", async () => {
+		const client = createMockClient();
+		const handler = new McpToolHandler(client);
+
+		const listed = await handler.executeTool("list_tags", {});
+		const added = await handler.executeTool("anki_add_note_tags", {
+			noteIds: [1234567890, 9876543210],
+			tags: ["programming", "mcp"],
+		});
+		const removed = await handler.executeTool("anki_remove_note_tags", {
+			noteId: 1234567890,
+			tags: ["mcp"],
+		});
+
+		expect(listed.structuredContent).toEqual({
+			tags: ["programming"],
+			count: 1,
+		});
+		expect(client.addTags).toHaveBeenCalledWith({
+			noteIds: [1234567890, 9876543210],
+			tags: ["programming", "mcp"],
+		});
+		expect(added.structuredContent).toEqual({
+			success: true,
+			operation: "added",
+			noteIds: [1234567890, 9876543210],
+			tags: ["programming", "mcp"],
+			updatedCount: 2,
+		});
+		expect(client.removeTags).toHaveBeenCalledWith({
+			noteIds: [1234567890],
+			tags: ["mcp"],
+		});
+		expect(removed.structuredContent).toEqual({
+			success: true,
+			operation: "removed",
+			noteIds: [1234567890],
+			tags: ["mcp"],
+			updatedCount: 1,
+		});
+	});
+
+	it("rejects whitespace tags for add/remove tag operations", async () => {
+		const handler = new McpToolHandler(createMockClient());
+
+		const result = await handler.executeTool("anki_add_note_tags", {
+			noteId: 1234567890,
+			tags: ["two words"],
+		});
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]).toMatchObject({
+			type: "text",
+			text: "Error: tags must not contain whitespace for this operation: two words",
 		});
 	});
 

--- a/src/mcpDeckTools.ts
+++ b/src/mcpDeckTools.ts
@@ -1,6 +1,6 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { toolResult } from "./mcpToolResponses.js";
-import { requireString } from "./mcpToolValidation.js";
+import { optionalBoolean, requireString } from "./mcpToolValidation.js";
 import type { AnkiClient } from "./utils.js";
 
 export const checkConnection = async (ankiClient: AnkiClient): Promise<CallToolResult> => {
@@ -17,9 +17,19 @@ export const sync = async (ankiClient: AnkiClient): Promise<CallToolResult> => {
 	});
 };
 
-export const listDecks = async (ankiClient: AnkiClient): Promise<CallToolResult> => {
+export const listDecks = async (
+	ankiClient: AnkiClient,
+	args: Record<string, unknown> = {}
+): Promise<CallToolResult> => {
+	const includeIds = optionalBoolean(args.includeIds, false);
 	const decks = await ankiClient.getDeckNames();
-	return toolResult({ decks, count: decks.length });
+	const deckIds = includeIds ? await ankiClient.getDeckNamesAndIds() : undefined;
+
+	return toolResult({
+		decks,
+		count: decks.length,
+		...(deckIds ? { deckIds } : {}),
+	});
 };
 
 export const createDeck = async (

--- a/src/mcpProtocol.test.ts
+++ b/src/mcpProtocol.test.ts
@@ -29,7 +29,11 @@ const createMockClient = (overrides: Partial<Record<keyof AnkiClient, unknown>> 
 		sync: jest.fn<() => Promise<void>>().mockResolvedValue(),
 		checkConnection: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
 		getDeckNames: jest.fn<() => Promise<string[]>>().mockResolvedValue(["Default"]),
+		getDeckNamesAndIds: jest
+			.fn<() => Promise<Record<string, number>>>()
+			.mockResolvedValue({ Default: 1 }),
 		createDeck: jest.fn<(name: string) => Promise<number>>().mockResolvedValue(42),
+		getTags: jest.fn<() => Promise<string[]>>().mockResolvedValue(["protocol"]),
 		getModelNames: jest.fn<() => Promise<string[]>>().mockResolvedValue(["Basic", "Cloze"]),
 		getModelFieldNames: jest
 			.fn<(modelName: string) => Promise<string[]>>()
@@ -51,6 +55,8 @@ const createMockClient = (overrides: Partial<Record<keyof AnkiClient, unknown>> 
 		notesInfo: jest.fn<AnkiClient["notesInfo"]>().mockResolvedValue([sampleNote]),
 		updateNoteFields: jest.fn<AnkiClient["updateNoteFields"]>().mockResolvedValue(),
 		updateNoteTags: jest.fn<AnkiClient["updateNoteTags"]>().mockResolvedValue(),
+		addTags: jest.fn<AnkiClient["addTags"]>().mockResolvedValue(),
+		removeTags: jest.fn<AnkiClient["removeTags"]>().mockResolvedValue(),
 		deleteNotes: jest.fn<(ids: number[]) => Promise<void>>().mockResolvedValue(),
 		...overrides,
 	}) as unknown as AnkiClient;
@@ -171,8 +177,27 @@ describe("MCP protocol integration", () => {
 		);
 		expect(JSON.parse(firstResourceText(resource.contents))).toEqual({
 			decks: ["Default"],
+			deckIds: { Default: 1 },
 			count: 1,
 		});
 		expect(ankiClient.checkConnection).toHaveBeenCalled();
+	});
+
+	it("reads tag resources through the MCP resource protocol", async () => {
+		const { client } = await createHarness();
+
+		const listed = await client.listResources();
+		const resource = await client.readResource({ uri: "anki://tags/all" });
+
+		expect(listed.resources).toContainEqual(
+			expect.objectContaining({
+				uri: "anki://tags/all",
+				mimeType: "application/json",
+			})
+		);
+		expect(JSON.parse(firstResourceText(resource.contents))).toEqual({
+			tags: ["protocol"],
+			count: 1,
+		});
 	});
 });

--- a/src/mcpResource.ts
+++ b/src/mcpResource.ts
@@ -41,6 +41,12 @@ export class McpResourceHandler {
 					description: "List of all available decks in Anki",
 					mimeType: "application/json",
 				},
+				{
+					uri: "anki://tags/all",
+					name: "All Tags",
+					description: "List of all tags used in Anki",
+					mimeType: "application/json",
+				},
 			],
 		};
 	}
@@ -82,6 +88,12 @@ export class McpResourceHandler {
 					description: "Complete list of available decks",
 					mimeType: "application/json",
 				},
+				{
+					uriTemplate: "anki://tags/all",
+					name: "All Tags",
+					description: "Complete list of tags used in Anki",
+					mimeType: "application/json",
+				},
 			],
 		};
 	}
@@ -98,7 +110,10 @@ export class McpResourceHandler {
 	}> {
 		await this.ankiClient.checkConnection();
 		if (uri === "anki://decks/all") {
-			const decks = await this.ankiClient.getDeckNames();
+			const [decks, deckIds] = await Promise.all([
+				this.ankiClient.getDeckNames(),
+				this.ankiClient.getDeckNamesAndIds(),
+			]);
 			return {
 				contents: [
 					{
@@ -107,7 +122,28 @@ export class McpResourceHandler {
 						text: JSON.stringify(
 							{
 								decks,
+								deckIds,
 								count: decks.length,
+							},
+							null,
+							2
+						),
+					},
+				],
+			};
+		}
+
+		if (uri === "anki://tags/all") {
+			const tags = await this.ankiClient.getTags();
+			return {
+				contents: [
+					{
+						uri,
+						mimeType: "application/json",
+						text: JSON.stringify(
+							{
+								tags,
+								count: tags.length,
 							},
 							null,
 							2

--- a/src/mcpTagTools.ts
+++ b/src/mcpTagTools.ts
@@ -1,0 +1,64 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { toolResult } from "./mcpToolResponses.js";
+import { parseNoteIds, requirePositiveInteger, requireStringArray } from "./mcpToolValidation.js";
+import type { AnkiClient } from "./utils.js";
+
+export const listTags = async (ankiClient: AnkiClient): Promise<CallToolResult> => {
+	const tags = await ankiClient.getTags();
+	return toolResult({ tags, count: tags.length });
+};
+
+export const addNoteTags = async (
+	ankiClient: AnkiClient,
+	args: Record<string, unknown>
+): Promise<CallToolResult> => {
+	const noteIds = parseTargetNoteIds(args);
+	const tags = parseTagsForAction(args.tags);
+
+	await ankiClient.addTags({ noteIds, tags });
+	return tagMutationResult("added", noteIds, tags);
+};
+
+export const removeNoteTags = async (
+	ankiClient: AnkiClient,
+	args: Record<string, unknown>
+): Promise<CallToolResult> => {
+	const noteIds = parseTargetNoteIds(args);
+	const tags = parseTagsForAction(args.tags);
+
+	await ankiClient.removeTags({ noteIds, tags });
+	return tagMutationResult("removed", noteIds, tags);
+};
+
+const parseTargetNoteIds = (args: Record<string, unknown>): number[] => {
+	const hasNoteId = args.noteId !== undefined;
+	const hasNoteIds = args.noteIds !== undefined;
+
+	if (hasNoteId === hasNoteIds) {
+		throw new Error("Provide exactly one of noteId or noteIds");
+	}
+
+	return hasNoteId ? [requirePositiveInteger(args.noteId, "noteId")] : parseNoteIds(args.noteIds);
+};
+
+const parseTagsForAction = (value: unknown): string[] => {
+	const tags = requireStringArray(value, "tags");
+	const invalidTags = tags.filter((tag) => /\s/.test(tag));
+
+	if (invalidTags.length > 0) {
+		throw new Error(
+			`tags must not contain whitespace for this operation: ${invalidTags.join(", ")}`
+		);
+	}
+
+	return tags;
+};
+
+const tagMutationResult = (operation: "added" | "removed", noteIds: number[], tags: string[]) =>
+	toolResult({
+		success: true,
+		operation,
+		noteIds,
+		tags,
+		updatedCount: noteIds.length,
+	});

--- a/src/mcpToolSchemas.ts
+++ b/src/mcpToolSchemas.ts
@@ -102,12 +102,23 @@ export const TOOLS: Tool[] = [
 	{
 		name: "anki_list_decks",
 		title: "List Anki Decks",
-		description: "List all available Anki decks.",
-		inputSchema: noInput,
+		description: "List all available Anki decks, optionally with deck IDs.",
+		inputSchema: inputSchema({
+			type: "object",
+			properties: {
+				includeIds: {
+					type: "boolean",
+					default: false,
+					description: "Include a deckIds object keyed by deck name when true.",
+				},
+			},
+			additionalProperties: false,
+		}),
 		outputSchema: outputSchema({
 			type: "object",
 			properties: {
 				decks: { type: "array", items: { type: "string" } },
+				deckIds: { type: "object", additionalProperties: { type: "number" } },
 				count: { type: "number" },
 			},
 			required: ["decks", "count"],
@@ -161,6 +172,110 @@ export const TOOLS: Tool[] = [
 		annotations: {
 			readOnlyHint: false,
 			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+	},
+	{
+		name: "anki_list_tags",
+		title: "List Anki Tags",
+		description: "List all tags currently used in the Anki collection.",
+		inputSchema: noInput,
+		outputSchema: outputSchema({
+			type: "object",
+			properties: {
+				tags: { type: "array", items: { type: "string" } },
+				count: { type: "number" },
+			},
+			required: ["tags", "count"],
+		}),
+		annotations: {
+			readOnlyHint: true,
+			openWorldHint: false,
+		},
+	},
+	{
+		name: "anki_add_note_tags",
+		title: "Add Tags To Anki Notes",
+		description: "Add one or more tags to a single note or multiple notes.",
+		inputSchema: inputSchema({
+			type: "object",
+			properties: {
+				noteId: { type: "number", minimum: 1, description: "Single note ID to update." },
+				noteIds: {
+					type: "array",
+					minItems: 1,
+					items: { type: "number", minimum: 1 },
+					description: "Multiple note IDs to update.",
+				},
+				tags: {
+					type: "array",
+					minItems: 1,
+					items: { type: "string", minLength: 1, pattern: "^\\S+$" },
+					description: "Tags to add. Use Anki tag names without whitespace.",
+				},
+			},
+			required: ["tags"],
+			oneOf: [{ required: ["noteId"] }, { required: ["noteIds"] }],
+			additionalProperties: false,
+		}),
+		outputSchema: outputSchema({
+			type: "object",
+			properties: {
+				success: { type: "boolean" },
+				operation: { type: "string" },
+				noteIds: { type: "array", items: { type: "number" } },
+				tags: { type: "array", items: { type: "string" } },
+				updatedCount: { type: "number" },
+			},
+			required: ["success", "operation", "noteIds", "tags", "updatedCount"],
+		}),
+		annotations: {
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+	},
+	{
+		name: "anki_remove_note_tags",
+		title: "Remove Tags From Anki Notes",
+		description: "Remove one or more tags from a single note or multiple notes.",
+		inputSchema: inputSchema({
+			type: "object",
+			properties: {
+				noteId: { type: "number", minimum: 1, description: "Single note ID to update." },
+				noteIds: {
+					type: "array",
+					minItems: 1,
+					items: { type: "number", minimum: 1 },
+					description: "Multiple note IDs to update.",
+				},
+				tags: {
+					type: "array",
+					minItems: 1,
+					items: { type: "string", minLength: 1, pattern: "^\\S+$" },
+					description: "Tags to remove. Use Anki tag names without whitespace.",
+				},
+			},
+			required: ["tags"],
+			oneOf: [{ required: ["noteId"] }, { required: ["noteIds"] }],
+			additionalProperties: false,
+		}),
+		outputSchema: outputSchema({
+			type: "object",
+			properties: {
+				success: { type: "boolean" },
+				operation: { type: "string" },
+				noteIds: { type: "array", items: { type: "number" } },
+				tags: { type: "array", items: { type: "string" } },
+				updatedCount: { type: "number" },
+			},
+			required: ["success", "operation", "noteIds", "tags", "updatedCount"],
+		}),
+		annotations: {
+			readOnlyHint: false,
+			destructiveHint: true,
 			idempotentHint: true,
 			openWorldHint: false,
 		},
@@ -492,6 +607,9 @@ export const LEGACY_TOOL_ALIASES: Record<string, string> = {
 	list_decks: "anki_list_decks",
 	sync: "anki_sync",
 	create_deck: "anki_create_deck",
+	list_tags: "anki_list_tags",
+	add_note_tags: "anki_add_note_tags",
+	remove_note_tags: "anki_remove_note_tags",
 	get_note_type_info: "anki_get_note_type_info",
 	create_note: "anki_create_note",
 	batch_create_notes: "anki_batch_create_notes",

--- a/src/mcpToolValidation.ts
+++ b/src/mcpToolValidation.ts
@@ -44,6 +44,14 @@ export const requirePositiveInteger = (value: unknown, fieldName: string): numbe
 	return value as number;
 };
 
+export const parseNoteIds = (value: unknown): number[] => {
+	if (!Array.isArray(value) || value.length === 0) {
+		throw new Error("noteIds must be a non-empty array");
+	}
+
+	return value.map((id, index) => requirePositiveInteger(id, `noteIds[${index}]`));
+};
+
 export const optionalInteger = (
 	value: unknown,
 	fieldName: string,

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -18,6 +18,7 @@ import {
 	searchNotes,
 	updateNote,
 } from "./mcpNoteTools.js";
+import { addNoteTags, listTags, removeNoteTags } from "./mcpTagTools.js";
 import { toolErrorResult } from "./mcpToolResponses.js";
 import { LEGACY_TOOL_ALIASES, TOOLS } from "./mcpToolSchemas.js";
 import { AnkiClient } from "./utils.js";
@@ -46,11 +47,17 @@ export class McpToolHandler {
 				case "anki_check_connection":
 					return await checkConnection(this.ankiClient);
 				case "anki_list_decks":
-					return await listDecks(this.ankiClient);
+					return await listDecks(this.ankiClient, args);
 				case "anki_sync":
 					return await sync(this.ankiClient);
 				case "anki_create_deck":
 					return await createDeck(this.ankiClient, args);
+				case "anki_list_tags":
+					return await listTags(this.ankiClient);
+				case "anki_add_note_tags":
+					return await addNoteTags(this.ankiClient, args);
+				case "anki_remove_note_tags":
+					return await removeNoteTags(this.ankiClient, args);
 				case "anki_list_note_types":
 					return await listNoteTypes(this.ankiClient);
 				case "anki_get_note_type_info":

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -250,6 +250,17 @@ export class AnkiClient {
 	}
 
 	/**
+	 * Get all deck names with their Anki IDs
+	 */
+	async getDeckNamesAndIds(): Promise<Record<string, number>> {
+		try {
+			return await this.executeWithRetry(() => this.client.deck.deckNamesAndIds());
+		} catch (error) {
+			throw this.wrapError(error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+
+	/**
 	 * Create a new deck
 	 */
 	async createDeck(name: string): Promise<number> {
@@ -303,6 +314,17 @@ export class AnkiClient {
 	async getModelStyling(modelName: string): Promise<{ css: string }> {
 		try {
 			return await this.executeWithRetry(() => this.client.model.modelStyling({ modelName }));
+		} catch (error) {
+			throw this.wrapError(error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+
+	/**
+	 * Get all tags in the collection
+	 */
+	async getTags(): Promise<string[]> {
+		try {
+			return await this.executeWithRetry(() => this.client.note.getTags());
 		} catch (error) {
 			throw this.wrapError(error instanceof Error ? error : new Error(String(error)));
 		}
@@ -476,6 +498,32 @@ export class AnkiClient {
 				this.client.note.updateNoteTags({
 					note: params.id,
 					tags: params.tags,
+				})
+			);
+		} catch (error) {
+			throw this.wrapError(error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+
+	async addTags(params: { noteIds: number[]; tags: string[] }): Promise<void> {
+		try {
+			await this.executeOnce(() =>
+				this.client.note.addTags({
+					notes: params.noteIds,
+					tags: params.tags.join(" "),
+				})
+			);
+		} catch (error) {
+			throw this.wrapError(error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+
+	async removeTags(params: { noteIds: number[]; tags: string[] }): Promise<void> {
+		try {
+			await this.executeOnce(() =>
+				this.client.note.removeTags({
+					notes: params.noteIds,
+					tags: params.tags.join(" "),
 				})
 			);
 		} catch (error) {


### PR DESCRIPTION
## Summary
- Add agent-facing tag tools: `anki_list_tags`, `anki_add_note_tags`, and `anki_remove_note_tags`.
- Extend `anki_list_decks` and `anki://decks/all` with optional deck ID metadata.
- Add `anki://tags/all`, update README, bundled Anki skill, and MCPB manifest tool listings.
- Cover the new tool/resource paths in unit and MCP protocol tests.

## Validation
- `npx tsc --noEmit`
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`
- `git diff --check`
- `pnpm lint && pnpm build && pnpm test`

## Note
- `pnpm run validate-mcp` currently fails because the existing script requires undeclared `ajv`; this is queued for the later MCP quality/docs branch rather than mixed into this feature PR.