### PR TITLE
[codex] Batch create notes with fewer Anki requests

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -47,6 +47,7 @@ const createMockClient = (overrides: Partial<Record<keyof AnkiClient, unknown>> 
 		}),
 		createModel: jest.fn<AnkiClient["createModel"]>().mockResolvedValue(),
 		addNote: jest.fn<AnkiClient["addNote"]>().mockResolvedValue(777),
+		addNotes: jest.fn<AnkiClient["addNotes"]>().mockResolvedValue([777]),
 		canAddNotesWithErrorDetail: jest
 			.fn<AnkiClient["canAddNotesWithErrorDetail"]>()
 			.mockResolvedValue([{ canAdd: true }]),
@@ -211,13 +212,14 @@ describe("McpToolHandler note workflows", () => {
 		const getModelFieldNames = jest
 			.fn<(modelName: string) => Promise<string[]>>()
 			.mockResolvedValue(["Front", "Back"]);
-		const addNote = jest
-			.fn<AnkiClient["addNote"]>()
-			.mockResolvedValueOnce(101)
-			.mockResolvedValueOnce(null);
+		const addNotes = jest.fn<AnkiClient["addNotes"]>().mockResolvedValue([101, null]);
+		const canAddNotesWithErrorDetail = jest
+			.fn<AnkiClient["canAddNotesWithErrorDetail"]>()
+			.mockResolvedValue([{ canAdd: true }, { canAdd: true }]);
 		const client = createMockClient({
 			getModelFieldNames,
-			addNote,
+			addNotes,
+			canAddNotesWithErrorDetail,
 			getDeckNames: jest.fn<() => Promise<string[]>>().mockResolvedValue(["Default"]),
 			getModelNames: jest.fn<() => Promise<string[]>>().mockResolvedValue(["Basic"]),
 		});
@@ -232,6 +234,7 @@ describe("McpToolHandler note workflows", () => {
 
 		expect(result.isError).toBe(true);
 		expect(getModelFieldNames).toHaveBeenCalledTimes(1);
+		expect(addNotes).toHaveBeenCalledTimes(1);
 		expect(result.structuredContent).toMatchObject({
 			total: 2,
 			successful: 1,
@@ -243,6 +246,46 @@ describe("McpToolHandler note workflows", () => {
 					index: 1,
 					error: "Anki rejected note creation without returning a note ID.",
 				},
+			],
+		});
+	});
+
+	it("preflights batch notes once and only submits creatable notes", async () => {
+		const addNotes = jest.fn<AnkiClient["addNotes"]>().mockResolvedValue([202]);
+		const canAddNotesWithErrorDetail = jest
+			.fn<AnkiClient["canAddNotesWithErrorDetail"]>()
+			.mockResolvedValue([{ canAdd: false, error: "duplicate" }, { canAdd: true }]);
+		const client = createMockClient({
+			addNotes,
+			canAddNotesWithErrorDetail,
+			getDeckNames: jest.fn<() => Promise<string[]>>().mockResolvedValue(["Default"]),
+			getModelNames: jest.fn<() => Promise<string[]>>().mockResolvedValue(["Basic"]),
+		});
+		const handler = new McpToolHandler(client);
+
+		const result = await handler.executeTool("anki_batch_create_notes", {
+			notes: [
+				{ type: "Basic", deck: "Default", fields: { Front: "Q1", Back: "A1" } },
+				{ type: "Basic", deck: "Default", fields: { Front: "Q2", Back: "A2" } },
+			],
+		});
+
+		expect(canAddNotesWithErrorDetail).toHaveBeenCalledTimes(1);
+		expect(addNotes).toHaveBeenCalledWith([
+			{
+				deckName: "Default",
+				modelName: "Basic",
+				fields: { Front: "Q2", Back: "A2" },
+				tags: [],
+				options: { allowDuplicate: false },
+			},
+		]);
+		expect(result.structuredContent).toMatchObject({
+			successful: 1,
+			failed: 1,
+			results: [
+				{ success: false, index: 0, error: "Cannot create note: duplicate" },
+				{ success: true, index: 1, noteId: 202 },
 			],
 		});
 	});

--- a/src/mcpNoteTools.ts
+++ b/src/mcpNoteTools.ts
@@ -9,12 +9,35 @@ import {
 	optionalInteger,
 	parseFields,
 	parseNoteInput,
+	parseNoteIds,
 	parseStringRecord,
 	parseTags,
 	requirePositiveInteger,
 	requireString,
 } from "./mcpToolValidation.js";
 import type { AnkiClient } from "./utils.js";
+
+type NotePayload = Parameters<AnkiClient["addNote"]>[0];
+
+type PreparedNote =
+	| {
+			index: number;
+			payload: NotePayload;
+	  }
+	| {
+			index: number;
+			error: string;
+	  };
+
+type PreparedPayload = Extract<PreparedNote, { payload: NotePayload }>;
+type PreparedError = Extract<PreparedNote, { error: string }>;
+type CheckedNote =
+	| (PreparedPayload & { canAdd: true })
+	| (PreparedPayload & { canAdd: false; error: string });
+
+const hasPayload = (item: PreparedNote): item is PreparedPayload => "payload" in item;
+const hasError = (item: PreparedNote): item is PreparedError => "error" in item;
+const canAdd = (item: CheckedNote): item is PreparedPayload & { canAdd: true } => item.canAdd;
 
 export const createNote = async (
 	ankiClient: AnkiClient,
@@ -79,59 +102,191 @@ export const batchCreateNotes = async (
 	const notes = args.notes.map((note, index) => parseNoteInput(note, index));
 	const allowDuplicate = optionalBoolean(args.allowDuplicate, false);
 	const stopOnError = optionalBoolean(args.stopOnError, false);
-	const knownDecks = new Set(await ankiClient.getDeckNames());
-	const knownModels = new Set(await ankiClient.getModelNames());
-	const fieldsCache = new Map<string, string[]>();
-	let results: BatchNoteResult[] = [];
 
-	for (let index = 0; index < notes.length; index++) {
-		try {
-			const note = notes[index];
-			if (!knownModels.has(note.type)) {
-				throw new Error(`Note type not found: ${note.type}`);
-			}
-
-			if (!knownDecks.has(note.deck)) {
-				await ankiClient.createDeck(note.deck);
-				knownDecks.add(note.deck);
-			}
-
-			const modelFields = await getCachedModelFields(ankiClient, note.type, fieldsCache);
-			const fields = normalizeFields(note.type, modelFields, note.fields);
-			const payload = {
-				deckName: note.deck,
-				modelName: note.type,
-				fields,
-				tags: note.tags,
-				options: { allowDuplicate },
-			};
-
-			await requireCanAddNote(ankiClient, payload);
-			const noteId = await ankiClient.addNote(payload);
-			if (noteId === null) {
-				throw new Error("Anki rejected note creation without returning a note ID.");
-			}
-
-			results = [...results, { success: true, noteId, index }];
-		} catch (error) {
-			results = [...results, { success: false, error: errorMessage(error), index }];
-			if (stopOnError) {
-				break;
-			}
-		}
+	if (stopOnError) {
+		return batchCreateNotesSequential(ankiClient, notes, allowDuplicate);
 	}
 
+	const prepared = await prepareBatchPayloads(ankiClient, notes, allowDuplicate);
+	const results = await createPreparedBatch(ankiClient, prepared);
+	return batchResult(notes.length, results);
+};
+
+const batchResult = (total: number, results: BatchNoteResult[]): CallToolResult => {
 	const successful = results.filter((item) => item.success).length;
 	const failed = results.filter((item) => !item.success).length;
 	return toolResult(
 		{
 			results,
-			total: notes.length,
+			total,
 			successful,
 			failed,
 		},
 		{ isError: failed > 0 }
 	);
+};
+
+const batchCreateNotesSequential = async (
+	ankiClient: AnkiClient,
+	notes: ReturnType<typeof parseNoteInput>[],
+	allowDuplicate: boolean
+): Promise<CallToolResult> => {
+	const prepared = await prepareBatchPayloads(ankiClient, notes, allowDuplicate, true);
+	const [firstError] = prepared.filter(hasError);
+	const ready = prepared.filter(hasPayload);
+	const created = await createPreparedBatch(ankiClient, ready);
+	const errors = firstError
+		? [{ success: false, error: firstError.error, index: firstError.index }]
+		: [];
+
+	return batchResult(
+		notes.length,
+		[...created, ...errors].sort((a, b) => a.index - b.index)
+	);
+};
+
+const prepareBatchPayloads = async (
+	ankiClient: AnkiClient,
+	notes: ReturnType<typeof parseNoteInput>[],
+	allowDuplicate: boolean,
+	stopOnError = false
+): Promise<PreparedNote[]> => {
+	let knownDecks = new Set(await ankiClient.getDeckNames());
+	const knownModels = new Set(await ankiClient.getModelNames());
+	const fieldsCache = new Map<string, string[]>();
+	let prepared: PreparedNote[] = [];
+
+	for (let index = 0; index < notes.length; index++) {
+		const preparedNote = await prepareBatchPayload(
+			ankiClient,
+			notes[index],
+			index,
+			allowDuplicate,
+			knownDecks,
+			knownModels,
+			fieldsCache
+		);
+		prepared = [...prepared, preparedNote.item];
+		knownDecks = preparedNote.knownDecks;
+
+		if (stopOnError && "error" in preparedNote.item) {
+			break;
+		}
+	}
+
+	return prepared;
+};
+
+const prepareBatchPayload = async (
+	ankiClient: AnkiClient,
+	note: ReturnType<typeof parseNoteInput>,
+	index: number,
+	allowDuplicate: boolean,
+	knownDecks: Set<string>,
+	knownModels: Set<string>,
+	fieldsCache: Map<string, string[]>
+): Promise<{ item: PreparedNote; knownDecks: Set<string> }> => {
+	try {
+		if (!knownModels.has(note.type)) {
+			throw new Error(`Note type not found: ${note.type}`);
+		}
+
+		const nextDecks = await ensureDeckExists(ankiClient, knownDecks, note.deck);
+		const modelFields = await getCachedModelFields(ankiClient, note.type, fieldsCache);
+		const fields = normalizeFields(note.type, modelFields, note.fields);
+
+		return {
+			item: {
+				index,
+				payload: {
+					deckName: note.deck,
+					modelName: note.type,
+					fields,
+					tags: note.tags,
+					options: { allowDuplicate },
+				},
+			},
+			knownDecks: nextDecks,
+		};
+	} catch (error) {
+		return {
+			item: { error: errorMessage(error), index },
+			knownDecks,
+		};
+	}
+};
+
+const ensureDeckExists = async (
+	ankiClient: AnkiClient,
+	knownDecks: Set<string>,
+	deck: string
+): Promise<Set<string>> => {
+	if (knownDecks.has(deck)) {
+		return knownDecks;
+	}
+
+	await ankiClient.createDeck(deck);
+	return new Set([...knownDecks, deck]);
+};
+
+const createPreparedBatch = async (
+	ankiClient: AnkiClient,
+	prepared: PreparedNote[]
+): Promise<BatchNoteResult[]> => {
+	const initialErrors = prepared
+		.filter(hasError)
+		.map((item) => ({ success: false, error: item.error, index: item.index }));
+	const ready = prepared.filter(hasPayload);
+	const checked = await checkPreparedNotes(ankiClient, ready);
+	const creatable = checked.filter(canAdd);
+	const created = await addPreparedNotes(ankiClient, creatable);
+	const rejected = checked
+		.filter((item) => !item.canAdd)
+		.map((item) => ({ success: false, error: item.error, index: item.index }));
+
+	return [...initialErrors, ...rejected, ...created].sort((a, b) => a.index - b.index);
+};
+
+const checkPreparedNotes = async (
+	ankiClient: AnkiClient,
+	ready: PreparedPayload[]
+): Promise<CheckedNote[]> => {
+	if (ready.length === 0) {
+		return [];
+	}
+
+	const checks = await ankiClient.canAddNotesWithErrorDetail(ready.map((item) => item.payload));
+	return ready.map((item, index) => {
+		const check = checks[index];
+		return check?.canAdd
+			? { ...item, canAdd: true as const }
+			: {
+					...item,
+					canAdd: false as const,
+					error: `Cannot create note: ${check && "error" in check ? check.error : "Anki rejected the note"}`,
+				};
+	});
+};
+
+const addPreparedNotes = async (
+	ankiClient: AnkiClient,
+	creatable: (PreparedPayload & { canAdd: true })[]
+): Promise<BatchNoteResult[]> => {
+	if (creatable.length === 0) {
+		return [];
+	}
+
+	const noteIds = await ankiClient.addNotes(creatable.map((item) => item.payload));
+	return creatable.map((item, index) => {
+		const noteId = noteIds?.[index] ?? null;
+		return noteId === null
+			? {
+					success: false,
+					error: "Anki rejected note creation without returning a note ID.",
+					index: item.index,
+				}
+			: { success: true, noteId, index: item.index };
+	});
 };
 
 export const searchNotes = async (
@@ -218,14 +373,6 @@ export const deleteNote = async (
 		deletedCount: noteIds.length,
 		noteIds,
 	});
-};
-
-const parseNoteIds = (value: unknown): number[] => {
-	if (!Array.isArray(value) || value.length === 0) {
-		throw new Error("noteIds must be a non-empty array");
-	}
-
-	return value.map((id, index) => requirePositiveInteger(id, `noteIds[${index}]`));
 };
 
 const prepareDeckAndModel = async (

--- a/src/mcpProtocol.test.ts
+++ b/src/mcpProtocol.test.ts
@@ -48,6 +48,7 @@ const createMockClient = (overrides: Partial<Record<keyof AnkiClient, unknown>> 
 		}),
 		createModel: jest.fn<AnkiClient["createModel"]>().mockResolvedValue(),
 		addNote: jest.fn<AnkiClient["addNote"]>().mockResolvedValue(777),
+		addNotes: jest.fn<AnkiClient["addNotes"]>().mockResolvedValue([777]),
 		canAddNotesWithErrorDetail: jest
 			.fn<AnkiClient["canAddNotesWithErrorDetail"]>()
 			.mockResolvedValue([{ canAdd: true }]),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,15 @@ export const DEFAULT_CONFIG: AnkiConfig = {
 	defaultDeck: "Default",
 };
 
+const normalizeNoteId = (noteId: number | string | null): number | null => {
+	if (noteId === null) {
+		return null;
+	}
+
+	const numericId = typeof noteId === "number" ? noteId : Number(noteId);
+	return Number.isFinite(numericId) ? numericId : null;
+};
+
 /**
  * Anti-corruption layer for yanki-connect
  * Provides a stable interface to interact with Anki
@@ -371,10 +380,13 @@ export class AnkiClient {
 			modelName: string;
 			fields: Record<string, string>;
 			tags?: string[];
+			options?: {
+				allowDuplicate?: boolean;
+			};
 		}[]
-	): Promise<(string | null)[] | null> {
+	): Promise<(number | null)[] | null> {
 		try {
-			return await this.executeOnce(() =>
+			const result = await this.executeOnce(() =>
 				this.client.note.addNotes({
 					notes: notes.map((note) => ({
 						deckName: note.deckName,
@@ -382,12 +394,14 @@ export class AnkiClient {
 						fields: note.fields,
 						tags: note.tags || [],
 						options: {
-							allowDuplicate: false,
+							allowDuplicate: note.options?.allowDuplicate || false,
 							duplicateScope: "deck",
 						},
 					})),
 				})
 			);
+
+			return result === null ? null : result.map((noteId) => normalizeNoteId(noteId));
 		} catch (error) {
 			throw this.wrapError(error instanceof Error ? error : new Error(String(error)));
 		}


### PR DESCRIPTION
## Summary
- Change the default `anki_batch_create_notes` path to preflight notes in one call and submit creatable notes through `addNotes` in one call.
- Keep per-note success/error results and retain the old ordered behavior for `stopOnError`.
- Normalize batch note IDs at the Anki client boundary.
- Add coverage for partial preflight rejection and batch add failures.

## Validation
- `npx tsc --noEmit`
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`
- `git diff --check`
- `pnpm lint && pnpm build && pnpm test`